### PR TITLE
fix: tags null 케이스 처리 in ChatpostDraggable 핸들러

### DIFF
--- a/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/handlers.tsx
+++ b/ganoverflow-next/src/app/chat/ChatSideBar/components/DragDropContainer/FolderDroppable/components/ChatpostDraggable/handlers.tsx
@@ -107,7 +107,7 @@ const getHandleLoadThisPost =
         chatPostId: chatpost.chatPostId,
         title: LoadedPost.chatpostName,
         category: LoadedPost.categoryName?.categoryName,
-        tags: [...LoadedPost.tags],
+        tags: LoadedPost.tags ? [...LoadedPost.tags] : [],
       },
     });
     setLoadedChatPairs(LoadedPost.chatPair);


### PR DESCRIPTION
https://github.com/modulersYJ/ganoverflow-front/issues/119#issuecomment-1696069940 관련 resolve fix입니다.

tags필드를  nullable한 필드로 확장했는데, 저는 확장 이후 태그 부여한 포스트에 대해서만 테스트를 했었네요ㅋㅋ
null케이스에 대한 고려를 안해서 발생한 에러였습니다.

변경 전 - 후 순입니다.

```ts
      loadedMeta: {
        folderId: LoadedPost.folderId,
        chatPostId: chatpost.chatPostId,
        title: LoadedPost.chatpostName,
        category: LoadedPost.categoryName?.categoryName,
        tags:  [...LoadedPost.tags] 
      },
```

```ts
      loadedMeta: {
        folderId: LoadedPost.folderId,
        chatPostId: chatpost.chatPostId,
        title: LoadedPost.chatpostName,
        category: LoadedPost.categoryName?.categoryName,
        tags: LoadedPost.tags ? [...LoadedPost.tags] : [],
      },
```