### PR TITLE
feat-userImage: 유저이미지 적용 (헤더,plp, pdp커멘트) & 서치아이콘 변경

### DIFF
--- a/ganoverflow-next/src/app/accounts/login/api/login.ts
+++ b/ganoverflow-next/src/app/accounts/login/api/login.ts
@@ -44,6 +44,7 @@ export const login = async (
   setSessionStorageItem("userData", {
     id: response.data.id,
     nickname: response.data.nickname,
+    imgUrl: response.data.imgUrl,
   });
 
   return response.data;

--- a/ganoverflow-next/src/app/layout.tsx
+++ b/ganoverflow-next/src/app/layout.tsx
@@ -19,7 +19,10 @@ import {
   useSetRecoilState,
 } from "recoil";
 import { userState } from "@/atoms/user";
-import { getSessionStorageItem } from "@/utils/common/sessionStorage";
+import {
+  TUserData,
+  getSessionStorageItem,
+} from "@/utils/common/sessionStorage";
 import { foldersWithChatpostsState } from "@/atoms/folder";
 import {
   TLoadChatStatus,
@@ -237,7 +240,7 @@ const UserDropdownButton = ({
   userData,
   onClickSetLogout,
 }: {
-  userData: { id: string; nickname: string };
+  userData: TUserData;
   onClickSetLogout: () => void;
 }) => {
   const setChatPairs = useSetRecoilState(chatPairsState);
@@ -266,11 +269,16 @@ const UserDropdownButton = ({
   };
 
   return (
-    <div className="relative 2xl:mr-10 flex flex-row justify-center group py-4">
+    <div className="relative 2xl:mr-10 flex flex-row justify-center group mr-8">
       <Link href="/" passHref>
         <button className="font-bold hover:text-gray-400">
-          {userData?.nickname}
-          <span className="text-xs">님</span>
+          <Image
+            className="rounded-full mt-1"
+            alt={userData.nickname}
+            width={38}
+            height={38}
+            src={userData?.imgUrl}
+          />
         </button>
       </Link>
 
@@ -311,7 +319,7 @@ const Footer = () => {
         </section>
         <ul className="section_social"></ul>
         <small className="txt_copyright">
-          © <a href="https://www.ganoverflow.com">GanOverflow</a> All rights
+          © <a href="https://www.ganoverflow.com">GANoverflow</a> All rights
           reserved.
         </small>
       </div>

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/commentRow.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/commentRow.tsx
@@ -6,7 +6,8 @@ import { putCommentLike } from "../../api/chatposts";
 import { useRouter } from "next/navigation";
 import { getSessionStorageItem } from "@/utils/common/sessionStorage";
 import { useSignedCheck } from "@/hooks/useSignedCheck";
-
+import Link from "next/link";
+import Image from "next/image";
 export default function CommentRow({
   comment,
   idx,
@@ -40,7 +41,15 @@ export default function CommentRow({
       id={`comment${comment.commentId}`}
       className="flex flex-row gap-2 border-b-2 w-full border-stone-500"
     >
-      <div className="border border-1 rounded-full m-4 w-20">사진</div>
+      <Link href={`/users/${comment?.user?.id}`}>
+        <Image
+          className="rounded-full mt-1"
+          alt={comment?.user?.nickname}
+          width={30}
+          height={30}
+          src={comment?.user?.imgUrl}
+        />
+      </Link>
       <div className="flex flex-col w-full ">
         <div className="flex flex-row justify-between">
           <div className="w-1/3 text-left py-2 flex gap-2">

--- a/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
+++ b/ganoverflow-next/src/app/posts/[chatPostId]/components/comments.tsx
@@ -4,7 +4,10 @@ import React, { ChangeEvent, useEffect, useState } from "react";
 import { postComment, postReComment } from "../../api/chatposts";
 import { useRouter } from "next/navigation";
 import { useSignedCheck } from "@/hooks/useSignedCheck";
-import { getSessionStorageItem } from "@/utils/common/sessionStorage";
+import {
+  TUserData,
+  getSessionStorageItem,
+} from "@/utils/common/sessionStorage";
 import dynamic from "next/dynamic";
 
 export function CommentBox({
@@ -198,7 +201,7 @@ export type TComments = {
   content: string;
   createdAt: string;
   delYn: string;
-  user: { username: string; nickname: string };
+  user: TUserData;
   userLikes: any[];
   parent?: TComments;
   childComments: TComments[];

--- a/ganoverflow-next/src/app/posts/layout.tsx
+++ b/ganoverflow-next/src/app/posts/layout.tsx
@@ -5,6 +5,7 @@ import { getCategoriesAndTopTags } from "./api/chatposts";
 import LottieCommunity from "./components/Lottie_Community";
 import LottieTrending from "./components/Lottie_Trending";
 import ChatIcon from "@mui/icons-material/Chat";
+import SearchIcon from "@mui/icons-material/Search";
 
 export const styleTransitionColor = `transition duration-300 ease-in-out`;
 
@@ -79,7 +80,7 @@ export default function PLPLayout({ children }: { children: React.ReactNode }) {
             className="flex flex-row gap-2 border-[1px] rounded-md border-primary outline-secondary bg-white dark:bg-[#121212]"
           >
             <input
-              className="h-11 w-full bg-inherit px-2 py-1 font-normal text-xs text-left"
+              className="relative h-11 w-full bg-inherit px-2 pl-3 py-1 font-normal text-xs text-left outline-none rounded-md"
               name="keyword"
               value={searchData}
               autoFocus
@@ -88,38 +89,10 @@ export default function PLPLayout({ children }: { children: React.ReactNode }) {
               onChange={handleInputChange}
             />
             <button
-              className=" text-white dark:text-black  rounded min-w-fit"
+              className="absolute right-1 top-2.5 text-white dark:text-black  rounded min-w-fit"
               onClick={handleSearch}
             >
-              <svg
-                fill="#12D761"
-                height="20px"
-                width="20px"
-                version="1.1"
-                id="Layer_1"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 512 512"
-                stroke="#12D761"
-              >
-                <g id="SVGRepo_bgCarrier" strokeWidth="0"></g>
-                <g
-                  id="SVGRepo_tracerCarrier"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                ></g>
-                <g id="SVGRepo_iconCarrier">
-                  <g>
-                    <g>
-                      <path d="M196.165,53.195c-75.163,0-136.312,61.149-136.312,136.312s61.15,136.312,136.312,136.312s136.312-61.149,136.312-136.312 S271.328,53.195,196.165,53.195z M196.165,299.221c-60.496,0-109.714-49.217-109.714-109.714 c0-60.497,49.219-109.714,109.714-109.714s109.714,49.217,109.714,109.714C305.879,250.004,256.662,299.221,196.165,299.221z"></path>{" "}
-                    </g>
-                  </g>
-                  <g>
-                    <g>
-                      <path d="M493.676,443.893L349.931,300.149c23.122-32.11,35.74-70.953,35.74-110.643C385.672,85.012,300.66,0,196.165,0 S6.659,85.012,6.659,189.506s85.012,189.507,189.507,189.507c33.349,0,65.797-8.715,94.494-25.293l146.593,146.594 c7.535,7.535,17.554,11.686,28.212,11.686s20.675-4.151,28.212-11.686C509.23,484.759,509.23,459.449,493.676,443.893z M474.869,481.507c-2.512,2.512-5.851,3.895-9.404,3.895c-3.552,0-6.893-1.383-9.404-3.895L302.037,327.483 c-2.571-2.571-5.975-3.895-9.407-3.895c-2.524,0-5.064,0.717-7.296,2.184c-26.543,17.431-57.375,26.644-89.169,26.644 c-89.829,0-162.909-73.08-162.909-162.909s73.08-162.909,162.909-162.909s162.909,73.08,162.909,162.909 c0,37.585-13.166,74.285-37.071,103.34c-4.35,5.286-3.975,13.011,0.864,17.852l152,152 C480.052,467.886,480.052,476.322,474.869,481.507z"></path>
-                    </g>
-                  </g>
-                </g>
-              </svg>
+              <SearchIcon className="!text-secondary dark:!text-white mr-1" />
             </button>
           </form>
 
@@ -199,17 +172,17 @@ export default function PLPLayout({ children }: { children: React.ReactNode }) {
                   {
                     title: "GANoverflow는 무슨 서비스인가?",
                     commentCnt: 12,
-                    url: "http://localhost:3000/posts/231",
+                    url: "/posts/231",
                   },
                   {
                     title: "ㅋㅋ를 코드화!!!",
                     commentCnt: 8,
-                    url: "http://localhost:3000/posts/131",
+                    url: "/posts/131",
                   },
                   {
                     title: "Say Cutely 시스템 명령 적용 모드",
                     commentCnt: 6,
-                    url: "http://localhost:3000/posts/193",
+                    url: "/posts/193",
                   },
                 ].map((item: any, idx: number) => (
                   <li key={idx}>

--- a/ganoverflow-next/src/app/posts/page.tsx
+++ b/ganoverflow-next/src/app/posts/page.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import Image from "next/image";
 import { getAllChatPost, getAllChatPostByCategory } from "./api/chatposts";
 import {
   formatTimeDifference,
@@ -80,71 +81,76 @@ export default async function PostPage({
           <div>
             {allPosts?.posts?.length === 10 ? (
               allPosts?.posts?.map((post: any, id: number) => (
-                <div
-                  className=" border border-x-0 border-spacing-2 border-zinc-500 hover:bg-slate-600 flex flex-col"
-                  key={id}
-                >
-                  {/* <div className="">{post?.chatPostId}</div> */}
-                  <div className="upperline flex flex-row pt-2 pb-1 gap-2 items-center">
-                    <div
-                      className={`flex flex-row text-xs ${
-                        post?.category?.categoryName ?? "hidden"
-                      } justify-start border w-fit h-6 mx-1 p-1 border-stone-500 rounded-md bg-slate-200 dark:bg-[#121212]  font-normal overflow-x-hidden whitespace-nowrap`}
-                    >
-                      {post?.category?.categoryName ?? ""}
-                    </div>
-                    <Link href={`/posts/${post?.chatPostId}`}>
-                      <div className="font-extrabold text-lg text-left">
-                        {post?.chatpostName}
+                <div key={id}>
+                  <div className=" border border-x-0 border-spacing-2 border-zinc-500 hover:bg-slate-600 flex flex-col">
+                    <div className="upperline flex flex-row pt-2 pb-1 gap-2 items-center">
+                      <div
+                        className={`flex flex-row text-xs ${
+                          post?.category?.categoryName ?? "hidden"
+                        } justify-start border w-fit h-6 mx-1 p-1 border-stone-500 rounded-md bg-slate-200 dark:bg-[#121212]  font-normal overflow-x-hidden whitespace-nowrap`}
+                      >
+                        {post?.category?.categoryName ?? ""}
                       </div>
-                    </Link>
-                    <div className="comments">[{post?.comments?.length}]</div>
-                  </div>
-                  <div className="lowerline flex flex-row items-center gap-2">
-                    <div className="userbox flex flex-row gap-2 pb-1 items-center">
-                      <div className="rounded-3xl w-8 h-8 p-2 bg-fuchsia-300 text-black text-xs whitespace-nowrap">
-                        {post?.user?.profile ?? "pic"}
-                      </div>
-                      <div className="">{post?.user?.nickname ?? ""}</div>
+                      <Link href={`/posts/${post?.chatPostId}`}>
+                        <div className="font-extrabold text-lg text-left">
+                          {post?.chatpostName}
+                        </div>
+                      </Link>
+                      <div className="comments">[{post?.comments?.length}]</div>
                     </div>
+                    <div className="lowerline flex flex-row items-center gap-2">
+                      <div className="userbox flex flex-row gap-2 pb-1 items-center">
+                        <Link href={`/users/${post?.user?.id}`}>
+                          <Image
+                            className="rounded-full mt-1"
+                            alt={post?.user?.nickname}
+                            width={30}
+                            height={30}
+                            src={post?.user?.imgUrl}
+                          />
+                        </Link>
 
-                    <div className="date">
-                      {formatTimeDifference(post?.createdAt, "ko-KR")}
-                    </div>
-                    <div className="viewcount flex flex-row gap-1">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="16"
-                        height="16"
-                        fill="currentColor"
-                        viewBox="0 0 16 16"
-                      >
-                        <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z" />{" "}
-                        <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z" />{" "}
-                      </svg>
-                      <span>{post?.viewCount}</span>
-                    </div>
-                    <div className="stars flex flex-row">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        height="1em"
-                        viewBox="0 0 512 512"
-                        style={{
-                          fill: "white",
-                          width: "25px",
-                          height: "1rem",
-                          fontSize: "0.8rem",
-                          pointerEvents: "none",
-                        }}
-                      >
-                        <path d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z" />
-                      </svg>
-                      <span>
-                        {post?.stars.reduce(
-                          (acc: number, curr: any) => acc + curr.value,
-                          0
-                        )}
-                      </span>
+                        <div className="">{post?.user?.nickname ?? ""}</div>
+                      </div>
+
+                      <div className="date">
+                        {formatTimeDifference(post?.createdAt, "ko-KR")}
+                      </div>
+                      <div className="viewcount flex flex-row gap-1">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          width="16"
+                          height="16"
+                          fill="currentColor"
+                          viewBox="0 0 16 16"
+                        >
+                          <path d="M16 8s-3-5.5-8-5.5S0 8 0 8s3 5.5 8 5.5S16 8 16 8zM1.173 8a13.133 13.133 0 0 1 1.66-2.043C4.12 4.668 5.88 3.5 8 3.5c2.12 0 3.879 1.168 5.168 2.457A13.133 13.133 0 0 1 14.828 8c-.058.087-.122.183-.195.288-.335.48-.83 1.12-1.465 1.755C11.879 11.332 10.119 12.5 8 12.5c-2.12 0-3.879-1.168-5.168-2.457A13.134 13.134 0 0 1 1.172 8z" />{" "}
+                          <path d="M8 5.5a2.5 2.5 0 1 0 0 5 2.5 2.5 0 0 0 0-5zM4.5 8a3.5 3.5 0 1 1 7 0 3.5 3.5 0 0 1-7 0z" />{" "}
+                        </svg>
+                        <span>{post?.viewCount}</span>
+                      </div>
+                      <div className="stars flex flex-row">
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          height="1em"
+                          viewBox="0 0 512 512"
+                          style={{
+                            fill: "white",
+                            width: "25px",
+                            height: "1rem",
+                            fontSize: "0.8rem",
+                            pointerEvents: "none",
+                          }}
+                        >
+                          <path d="M313.4 32.9c26 5.2 42.9 30.5 37.7 56.5l-2.3 11.4c-5.3 26.7-15.1 52.1-28.8 75.2H464c26.5 0 48 21.5 48 48c0 18.5-10.5 34.6-25.9 42.6C497 275.4 504 288.9 504 304c0 23.4-16.8 42.9-38.9 47.1c4.4 7.3 6.9 15.8 6.9 24.9c0 21.3-13.9 39.4-33.1 45.6c.7 3.3 1.1 6.8 1.1 10.4c0 26.5-21.5 48-48 48H294.5c-19 0-37.5-5.6-53.3-16.1l-38.5-25.7C176 420.4 160 390.4 160 358.3V320 272 247.1c0-29.2 13.3-56.7 36-75l7.4-5.9c26.5-21.2 44.6-51 51.2-84.2l2.3-11.4c5.2-26 30.5-42.9 56.5-37.7zM32 192H96c17.7 0 32 14.3 32 32V448c0 17.7-14.3 32-32 32H32c-17.7 0-32-14.3-32-32V224c0-17.7 14.3-32 32-32z" />
+                        </svg>
+                        <span>
+                          {post?.stars.reduce(
+                            (acc: number, curr: any) => acc + curr.value,
+                            0
+                          )}
+                        </span>
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/ganoverflow-next/src/utils/common/sessionStorage.ts
+++ b/ganoverflow-next/src/utils/common/sessionStorage.ts
@@ -3,6 +3,7 @@
 export type TUserData = {
   id: string;
   nickname: string;
+  imgUrl: string;
 };
 
 export function setSessionStorageItem(key: string, value: TUserData | null) {


### PR DESCRIPTION
#### 기본 유저 이미지 셋입니다.
![image](https://github.com/modulersYJ/ganoverflow-front/assets/65459616/0939d02c-886e-4e6c-a199-119cad7fb3d2)

https://ebizcap.s3.ap-northeast-2.amazonaws.com/ganoverflow_user_profile/user_primary.svg
https://ebizcap.s3.ap-northeast-2.amazonaws.com/ganoverflow_user_profile/user_red.svg
https://ebizcap.s3.ap-northeast-2.amazonaws.com/ganoverflow_user_profile/user_blue.svg
https://ebizcap.s3.ap-northeast-2.amazonaws.com/ganoverflow_user_profile/user_yellow.svg
https://ebizcap.s3.ap-northeast-2.amazonaws.com/ganoverflow_user_profile/user_white.svg

#### 서치아이콘은 mui로 바꾸고 색, 포지션 등 소소하게 수정했슴니다

@hongregii 