### PR TITLE
feat-chat: parital answer 해결을 위해 토큰 수 제한 해제

### DIFF
--- a/ganoverflow-next/src/app/chat/api/route.ts
+++ b/ganoverflow-next/src/app/chat/api/route.ts
@@ -21,7 +21,7 @@ export async function POST(req: Request): Promise<Response> {
     top_p: 1,
     frequency_penalty: 0,
     presence_penalty: 0,
-    max_tokens: 2000,
+    max_tokens: 4096,
     stream: true,
     n: 1,
   };


### PR DESCRIPTION
Partial Answer 문제를 해결하기 위해 아래와 같이 `max_tokens`를 3000에서 3.5 turbo의 최대치인 4096으로 늘렸습니다.

<br/>

```
  const payload: OpenAIStreamPayload = {
    model: "gpt-3.5-turbo",
    messages: prompts,
    temperature: 0.7,
    top_p: 1,
    frequency_penalty: 0,
    presence_penalty: 0,
    max_tokens: 4096,
    stream: true,
    n: 1,
  };
```